### PR TITLE
Add a build script (for Windows only)

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+go build --ldflags "-s -w" -o redditdl.exe ./cmd/redditdl/redditdl.go


### PR DESCRIPTION
It is easier to run .\build.bat from console now that the main file is deeply nested inside the project folder