### PR TITLE
Rewrite using channels and a worker pool

### DIFF
--- a/cmd/redditdl/redditdl.go
+++ b/cmd/redditdl/redditdl.go
@@ -23,7 +23,7 @@ var (
 func main() {
 	flag.Parse()
 
-	ds := downloader.DownloaderSettings{
+	s := downloader.Settings{
 		Verbose:      *v,
 		ShowProgress: *p,
 		IncludeVideo: *inclVideo,
@@ -36,15 +36,15 @@ func main() {
 		MinHeight:    *h,
 	}
 
-	log := logging.GetLogger(ds.Verbose)
+	log := logging.GetLogger(s.Verbose)
 
 	// Print the configuration
-	log.Debugf("Using parameters: %#v", ds)
+	log.Debugf("Using parameters: %#v", s)
 
 	// Download the media
 	log.Info("Started downloading media")
 
-	count, err := downloader.Download(ds, downloader.Filters)
+	count, err := downloader.Download(s, downloader.Filters)
 	if err != nil {
 		log.Fatal("error downloading media", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12
 	go.uber.org/zap v1.21.0
 	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -2,11 +2,13 @@ package downloader
 
 import (
 	"os"
+	"path"
+	"strconv"
 	"testing"
 )
 
 func TestDownload(t *testing.T) {
-	cfg := DownloaderSettings{
+	s := Settings{
 		Verbose:      false,
 		ShowProgress: false,
 		IncludeVideo: false,
@@ -19,12 +21,30 @@ func TestDownload(t *testing.T) {
 		MinHeight:    0,
 	}
 
-	count, err := Download(cfg, Filters)
+	count, err := Download(s, Filters)
 	if err != nil {
-		t.Fatalf("Download(%#v) error: %v", cfg, err)
+		t.Fatalf("Download(%#v) error: %v", s, err)
 	}
 
-	if count != uint32(cfg.Count) {
-		t.Fatalf("Download(%#v) loaded %v media, expected %v", cfg, count, cfg.Count)
+	if count != int64(s.Count) {
+		t.Fatalf("Download(%#v) loaded %v media, expected %v", s, count, s.Count)
+	}
+}
+
+func BenchmarkDownload(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := Settings{
+			Verbose:      false,
+			ShowProgress: false,
+			IncludeVideo: true,
+			Subreddit:    "wallpaper",
+			Sorting:      "best",
+			Timeframe:    "all",
+			Directory:    path.Join(os.TempDir(), strconv.Itoa(i)),
+			Count:        35,
+			MinWidth:     1920,
+			MinHeight:    1080,
+		}
+		Download(s, Filters)
 	}
 }

--- a/pkg/downloader/filters.go
+++ b/pkg/downloader/filters.go
@@ -7,32 +7,32 @@ var Filters = []Filter{whFilter, urlFilter}
 
 // Interface that filters the given slice and returns the mutated version of it.
 type Filter interface {
-	Filter([]toDownload, *DownloaderSettings) []toDownload
+	Filter([]content, *Settings) []content
 }
 
 // []downloadable according to its own logic.
 // FilterFunc implements filter interface and expects the function to return a new slice.
-type FilterFunc func([]toDownload, *DownloaderSettings) []toDownload
+type FilterFunc func([]content, *Settings) []content
 
-func (f FilterFunc) Filter(td []toDownload, ds *DownloaderSettings) []toDownload {
-	return f(td, ds)
+func (f FilterFunc) Filter(c []content, s *Settings) []content {
+	return f(c, s)
 }
 
 var (
-	whFilter FilterFunc = func(td []toDownload, ds *DownloaderSettings) []toDownload {
-		f := make([]toDownload, 0)
-		for _, m := range td {
-			if m.Data.Width >= ds.MinWidth && m.Data.Height >= ds.MinHeight {
+	whFilter FilterFunc = func(c []content, s *Settings) []content {
+		f := make([]content, 0)
+		for _, m := range c {
+			if m.Width >= s.MinWidth && m.Height >= s.MinHeight {
 				f = append(f, m)
 			}
 		}
 		return f
 	}
 
-	urlFilter FilterFunc = func(td []toDownload, ds *DownloaderSettings) []toDownload {
-		f := make([]toDownload, 0)
-		for _, m := range td {
-			if len(m.Data.URL) > 0 && utils.IsURL(m.Data.URL) {
+	urlFilter FilterFunc = func(c []content, s *Settings) []content {
+		f := make([]content, 0)
+		for _, m := range c {
+			if len(m.URL) > 0 && utils.IsURL(m.URL) {
 				f = append(f, m)
 			}
 		}

--- a/pkg/downloader/responses.go
+++ b/pkg/downloader/responses.go
@@ -1,18 +1,5 @@
 package downloader
 
-// toDownload contains information which is required to filter by resolution,
-// download and store a video or an image.
-type toDownload struct {
-	Name    string
-	Data    imgData
-	IsVideo bool
-}
-
-type imgData struct {
-	URL           string
-	Width, Height int
-}
-
 type posts struct {
 	Kind string    `json:"kind"`
 	Data postsData `json:"data"`


### PR DESCRIPTION
Now, we have the following structure:

1. Single goroutine fetches media and sends it to a channel.

2. 16 goroutines watch the queue and download media from it,
after downloading, they send the result to the file queue.

3. Single goroutine waits for items in file queue and
saves each file to disk sequentially.

This makes downloads happen faster if there are multiple images in my tests.

Before:
goos: windows
goarch: amd64
pkg: redditdl/pkg/downloader
cpu: AMD Ryzen 5 3600 6-Core Processor              
BenchmarkDownload-12             1  19739944800 ns/op   9959408 B/op     51208 allocs/op
PASS
ok    redditdl/pkg/downloader  19.862s

After:
goos: windows
goarch: amd64
pkg: redditdl/pkg/downloader
cpu: AMD Ryzen 5 3600 6-Core Processor              
BenchmarkDownload-12             1  12474094500 ns/op  296305624 B/op     31833 allocs/op
PASS
ok    redditdl/pkg/downloader  12.688s