### PR TITLE
Improve overall performance and use less memory

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -197,23 +197,25 @@ func (dl *downloader) ShowProgress(exit <-chan bool) {
 func postsToContent(typ configuration.ContentType, children []api.Child) []api.Content {
 	data := make([]api.Content, 0, len(children))
 	for i := 0; i < len(children); i++ {
-		value := &children[i].Data
-		if !value.IsVideo && typ == configuration.ContentAny || typ == configuration.ContentImages {
-			for _, img := range value.Preview.Images {
-				data = append(data, api.Content{
-					Name:    value.Title,
-					URL:     strings.ReplaceAll(img.Source.URL, "&amp;s", "&s"),
-					Width:   img.Source.Width,
-					Height:  img.Source.Height,
-					IsVideo: false,
-				})
+		v := &children[i].Data
+		if !v.IsVideo && (typ == configuration.ContentAny || typ == configuration.ContentImages) {
+			if len(v.Preview.Images) != 1 {
+				continue
 			}
-		} else if value.IsVideo && typ == configuration.ContentAny || typ == configuration.ContentVideos {
+			img := &v.Preview.Images[0]
 			data = append(data, api.Content{
-				Name:    value.Title,
-				URL:     strings.ReplaceAll(value.Media.RedditVideo.ScrubberMediaURL, "&amp;s", "&s"),
-				Width:   value.Media.RedditVideo.Width,
-				Height:  value.Media.RedditVideo.Height,
+				Name:    v.Title,
+				URL:     strings.ReplaceAll(img.Source.URL, "&amp;s", "&s"),
+				Width:   img.Source.Width,
+				Height:  img.Source.Height,
+				IsVideo: false,
+			})
+		} else if v.IsVideo && (typ == configuration.ContentAny || typ == configuration.ContentVideos) {
+			data = append(data, api.Content{
+				Name:    v.Title,
+				URL:     strings.ReplaceAll(v.Media.RedditVideo.ScrubberMediaURL, "&amp;s", "&s"),
+				Width:   v.Media.RedditVideo.Width,
+				Height:  v.Media.RedditVideo.Height,
 				IsVideo: true,
 			})
 		}

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -41,27 +41,79 @@ func TestDownload(t *testing.T) {
 	}
 }
 
-func BenchmarkDownload(b *testing.B) {
-	b.StopTimer()
-
-	cfg := configuration.Config{
-		Directory:    "",
+func setupConfig(count int64) configuration.Config {
+	return configuration.Config{
+		Directory:    strconv.Itoa(int(count)),
 		Subreddit:    "wallpaper",
 		Sorting:      "best",
 		Timeframe:    "all",
 		Orientation:  "",
-		Count:        35,
-		MinWidth:     1920,
-		MinHeight:    1080,
+		Count:        count,
+		MinWidth:     0,
+		MinHeight:    0,
 		WorkerCount:  configuration.DefaultWorkerCount,
 		SleepTime:    configuration.DefaultSleepTime,
 		Verbose:      false,
 		ShowProgress: false,
-		ContentType:  configuration.ContentAny,
+		ContentType:  configuration.ContentImages,
 	}
+}
 
+func BenchmarkDownload1(b *testing.B) {
+	cfg := setupConfig(1)
 	client := downloader.New(&cfg, filter.Default()...)
-	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		cfg.Directory = path.Join(os.TempDir(), strconv.Itoa(i))
+		if stats := client.Download(); len(stats.Errors()) != 0 {
+			for _, err := range stats.Errors() {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkDownload10(b *testing.B) {
+	cfg := setupConfig(10)
+	client := downloader.New(&cfg, filter.Default()...)
+	for i := 0; i < b.N; i++ {
+		cfg.Directory = path.Join(os.TempDir(), strconv.Itoa(i))
+		if stats := client.Download(); len(stats.Errors()) != 0 {
+			for _, err := range stats.Errors() {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkDownload25(b *testing.B) {
+	cfg := setupConfig(25)
+	client := downloader.New(&cfg, filter.Default()...)
+	for i := 0; i < b.N; i++ {
+		cfg.Directory = path.Join(os.TempDir(), strconv.Itoa(i))
+		if stats := client.Download(); len(stats.Errors()) != 0 {
+			for _, err := range stats.Errors() {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkDownload50(b *testing.B) {
+	cfg := setupConfig(50)
+	client := downloader.New(&cfg, filter.Default()...)
+	for i := 0; i < b.N; i++ {
+		cfg.Directory = path.Join(os.TempDir(), strconv.Itoa(i))
+		if stats := client.Download(); len(stats.Errors()) != 0 {
+			for _, err := range stats.Errors() {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkDownload100(b *testing.B) {
+	cfg := setupConfig(100)
+	client := downloader.New(&cfg, filter.Default()...)
 	for i := 0; i < b.N; i++ {
 		cfg.Directory = path.Join(os.TempDir(), strconv.Itoa(i))
 		if stats := client.Download(); len(stats.Errors()) != 0 {

--- a/fetch/api/api.go
+++ b/fetch/api/api.go
@@ -13,55 +13,35 @@ type Content struct {
 // Everything below mimics reddit's responses.
 
 type Posts struct {
-	Kind string    `json:"kind"`
-	Data PostsData `json:"data"`
-}
-
-type PostsData struct {
-	After    string  `json:"after"`
-	Children []Child `json:"children"`
+	Data struct {
+		After    string  `json:"after"`
+		Children []Child `json:"children"`
+	} `json:"data"`
 }
 
 type Child struct {
-	Kind string    `json:"kind"`
-	Data ChildData `json:"data"`
-}
-
-type ChildData struct {
-	Title     string  `json:"title"`
-	Thumbnail string  `json:"thumbnail"`
-	Preview   Preview `json:"preview"`
-	Media     struct {
-		RedditVideo Video `json:"reddit_video"`
-	} `json:"media"`
-	IsVideo bool `json:"is_video"`
+	Data struct {
+		Media struct {
+			RedditVideo *Video `json:"reddit_video"`
+		} `json:"media"`
+		Title   string `json:"title"`
+		Preview struct {
+			Images []struct {
+				Source *ImageData `json:"source"`
+			} `json:"images"`
+		}
+		IsVideo bool `json:"is_video"`
+	} `json:"data"`
 }
 
 type Video struct {
-	FallbackURL       string `json:"fallback_url"`
-	TranscodingStatus string `json:"transcoding_status"`
-	ScrubberMediaURL  string `json:"scrubber_media_url"`
-	DashURL           string `json:"dash_url"`
-	HlsURL            string `json:"hls_url"`
-	BitrateKbps       int    `json:"bitrate_kbps"`
-	Height            int    `json:"height"`
-	Duration          int    `json:"duration"`
-	Width             int    `json:"width"`
-	IsGif             bool   `json:"is_gif"`
+	ScrubberMediaURL string `json:"scrubber_media_url"`
+	Height           int    `json:"height"`
+	Width            int    `json:"width"`
 }
 
 type ImageData struct {
 	URL    string `json:"url"`
-	Width  int    `json:"width"`
 	Height int    `json:"height"`
-}
-
-type Preview struct {
-	Images []Image `json:"images"`
-}
-
-type Image struct {
-	ID          string      `json:"id"`
-	Resolutions []ImageData `json:"resolutions"`
-	Source      ImageData   `json:"source"`
+	Width  int    `json:"width"`
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -83,18 +83,12 @@ func File(content *api.Content) (*files.File, error) {
 		extension = split[1]
 	}
 
-	f := &files.File{
-		Name:      content.Name,
-		Extension: extension,
-		Data:      nil,
-	}
-
-	_, err = io.Copy(f, response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, "couldn't copy response body")
+		return nil, fmt.Errorf("%w: %s", err, "couldn't read response body")
 	}
 
-	return f, nil
+	return files.New(content.Name, extension, b), nil
 }
 
 // Posts fetches a json file from reddit containing information

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -83,12 +83,18 @@ func File(content *api.Content) (*files.File, error) {
 		extension = split[1]
 	}
 
-	b, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, "couldn't read response body")
+	f := &files.File{
+		Name:      content.Name,
+		Extension: extension,
+		Data:      nil,
 	}
 
-	return files.New(content.Name, extension, b), nil
+	_, err = io.Copy(f, response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, "couldn't copy response body")
+	}
+
+	return f, nil
 }
 
 // Posts fetches a json file from reddit containing information

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -23,6 +23,8 @@ const (
 	clientTimeout = time.Minute
 )
 
+var client = NewClient()
+
 var ErrInvalidStatus = errors.New("unexpected status code in response")
 
 // NewClient returns a pointer to http.Client configured to work with reddit.
@@ -54,8 +56,6 @@ func FormatURL(cfg *configuration.Config, after string) string {
 
 // File fetches data for a file from reddit's api and returns a *File.
 func File(content *api.Content) (*files.File, error) {
-	client := NewClient()
-
 	request, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, content.URL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", err, "couldn't create the request")
@@ -94,8 +94,6 @@ func File(content *api.Content) (*files.File, error) {
 // Posts fetches a json file from reddit containing information
 // about the posts using the given configuration.
 func Posts(path string) (*api.Posts, error) {
-	client := NewClient()
-
 	request, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, path, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", err, "couldn't create the request")

--- a/files/files.go
+++ b/files/files.go
@@ -109,14 +109,7 @@ func NavigateTo(dir string, createDir bool) error {
 
 // Save saves the file to the provided path/filename.
 func Save(filename string, b []byte) error {
-	f, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("%w: couldn't create file(name=%s)", err, filename)
-	}
-	if _, err := f.Write(b); err != nil {
-		if err := os.Remove(filename); err != nil {
-			return fmt.Errorf("%w: couldn't remove file(name=%s)", err, filename)
-		}
+	if err := os.WriteFile(filename, b, 0o600); err != nil {
 		return fmt.Errorf("%w: couldn't write file(name=%s)", err, filename)
 	}
 	return nil

--- a/files/files.go
+++ b/files/files.go
@@ -16,13 +16,6 @@ type File struct {
 	Data            []byte
 }
 
-// Write implements io.Writer.
-func (f *File) Write(p []byte) (int, error) {
-	f.Data = make([]byte, 0, len(p)) // this saves a lot of memory according to benchmarks
-	f.Data = append(f.Data, p...)
-	return len(p), nil
-}
-
 // New returns a pointer to a new File.
 func New(name, ext string, data []byte) *File {
 	return &File{

--- a/files/files.go
+++ b/files/files.go
@@ -17,6 +17,13 @@ type File struct {
 	Data            []byte
 }
 
+// Write implements io.Writer.
+func (f *File) Write(p []byte) (int, error) {
+	f.Data = make([]byte, 0, len(p)) // this saves a lot of memory according to benchmarks
+	f.Data = append(f.Data, p...)
+	return len(p), nil
+}
+
 // New returns a pointer to a new File.
 func New(name, ext string, data []byte) *File {
 	return &File{

--- a/files/files.go
+++ b/files/files.go
@@ -18,7 +18,6 @@ type File struct {
 
 // Write implements io.Writer.
 func (f *File) Write(p []byte) (int, error) {
-	f.Data = make([]byte, 0, len(p)) // this saves a lot of memory according to benchmarks
 	f.Data = append(f.Data, p...)
 	return len(p), nil
 }

--- a/files/files.go
+++ b/files/files.go
@@ -18,6 +18,7 @@ type File struct {
 
 // Write implements io.Writer.
 func (f *File) Write(p []byte) (int, error) {
+	f.Data = make([]byte, 0, len(p)) // this saves a lot of memory according to benchmarks
 	f.Data = append(f.Data, p...)
 	return len(p), nil
 }


### PR DESCRIPTION
This is the comparison to the current implementation (old):

```
name            old time/op    new time/op    delta
Download1-12       491ms ± 0%     252ms ± 0%   ~     (p=1.000 n=1+1)
Download10-12      2.05s ± 0%     1.40s ± 0%   ~     (p=1.000 n=1+1)
Download25-12      3.79s ± 0%     3.86s ± 0%   ~     (p=1.000 n=1+1)
Download50-12      5.31s ± 0%     4.80s ± 0%   ~     (p=1.000 n=1+1)
Download100-12     7.75s ± 0%     7.37s ± 0%   ~     (p=1.000 n=1+1)

name            old alloc/op   new alloc/op   delta
Download1-12      7.04MB ± 0%    6.75MB ± 0%   ~     (p=1.000 n=1+1)
Download10-12      110MB ± 0%     109MB ± 0%   ~     (p=1.000 n=1+1)
Download25-12      204MB ± 0%     202MB ± 0%   ~     (p=1.000 n=1+1)
Download50-12      553MB ± 0%     549MB ± 0%   ~     (p=1.000 n=1+1)
Download100-12    1.06GB ± 0%    1.05GB ± 0%   ~     (p=1.000 n=1+1)

name            old allocs/op  new allocs/op  delta
Download1-12       3.30k ± 0%     0.46k ± 0%   ~     (p=1.000 n=1+1)
Download10-12      20.3k ± 0%     14.1k ± 0%   ~     (p=1.000 n=1+1)
Download25-12      45.4k ± 0%     27.3k ± 0%   ~     (p=1.000 n=1+1)
Download50-12      89.1k ± 0%     54.1k ± 0%   ~     (p=1.000 n=1+1)
Download100-12      174k ± 0%       69k ± 0%   ~     (p=1.000 n=1+1)
```