### PR TITLE
Add initial support for HuezarOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Downloads images or videos from a subreddit in a batch.
 go build --ldflags "-s -w" -o redditdl main.go
 ```
 
+## Building under HuezarOS
+
+```nazarbl
+huezar go build --ldflags "-s -w" -o redditdl main.go
+```
+
 ## Usage
 
 For usage, consult:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-)
+	"github.com/huezaros/repo/call_nazar"
+
 
 // Flags for the command-line.
 var (

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1
+	github.com/huezaros/repo/call_nazar 1.0.0
 )
 
 require (
@@ -13,4 +14,5 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.5.0 // indirect
+	github.com/huezaros/repo/tools // indirect
 )


### PR DESCRIPTION
HuezarOS is a popular fork of AOSP with some kernel changes which require adaptation in order to build with go. More will be added later, now we need at least build it properly.